### PR TITLE
Staging:  Fix maxmind's data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,14 @@ grape --dp 20002 --aph 40001 --bn '127.0.0.1:20001'
 
 ### Update Geo/ASN data
 
-First replace YOUR_LICENSE_KEY with your free license key optained through 
+First, export your license key, for staging/prod we have a comercial
+license.  For dev, you can get a free key key optained through 
 https://dev.maxmind.com/geoip/geolite2-free-geolocation-data?lang=en 
-in package.json and update-asn-db.sh files, then run: 
 
-For Production/Staging
+export MAXMIND_LICENSE='your secret license'
+
 ```
 npm run update-geo-data
-npm run update-asn-data
-```
-
-For Development
-```
-npm run update-geo-data-free
 npm run update-asn-data
 ```
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "unit": "mocha",
     "format": "standard --fix",
     "lint": "standard",
-    "update-geo-data-free": "LICENSE_KEY=YOUR_LICENSE_KEY node ./node_modules/geoip-lite/scripts/updatedb.js",
-    "update-geo-data": "LICENSE_KEY=YOUR_LICENSE_KEY node ./scripts/updatedb.js",
+    "update-geo-data": "./update-geo-db.sh",
     "update-asn-data": "./update-asn-db.sh"
   },
   "dependencies": {
@@ -25,7 +24,7 @@
     "bfx-wrk-api": "git+https://github.com/bitfinexcom/bfx-wrk-api.git",
     "bfx-wrk-base": "git+https://github.com/bitfinexcom/bfx-wrk-base.git",
     "colors": "1.4.0",
-    "geoip-lite": "1.4.2",
+    "geoip-lite": "1.4.6",
     "grenache-nodejs-http": "^0.7.12",
     "grenache-nodejs-link": "^0.7.12",
     "https-proxy-agent": "5.0.0",

--- a/update-asn-db.sh
+++ b/update-asn-db.sh
@@ -3,7 +3,13 @@
 DESTDIR='./mmdb'
 ME="${BASH_SOURCE[0]}"
 
-wget --quiet --output-document="${DESTDIR}/GeoLite2-ASN.tar.gz" 'https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&license_key=YOUR_LICENSE_KEY&suffix=tar.gz' || {
+if [ -z ${MAXMIND_LICENSE+x} ]
+then
+  echo "Error, MAXMIND_LICENSE env must be set"
+fi
+
+
+wget --quiet --output-document="${DESTDIR}/GeoLite2-ASN.tar.gz" "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&license_key=$MAXMIND_LICENSE&suffix=tar.gz" || {
   echo "${ME##*/}: fatal error: download failed." >&2
   exit 1
 }

--- a/update-geo-db.sh
+++ b/update-geo-db.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+DESTDIR='./mmdb'
+ME="${BASH_SOURCE[0]}"
+
+if [ -z ${MAXMIND_LICENSE+x} ]
+then
+  echo "Error, MAXMIND_LICENSE env must be set"
+fi
+
+env LICENSE_KEY="$MAXMIND_LICENSE" node ./scripts/updatedb.js
+
+exit 0

--- a/update-geo-db.sh
+++ b/update-geo-db.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-DESTDIR='./mmdb'
-ME="${BASH_SOURCE[0]}"
-
 if [ -z ${MAXMIND_LICENSE+x} ]
 then
   echo "Error, MAXMIND_LICENSE env must be set"

--- a/workers/api.net.util.wrk.js
+++ b/workers/api.net.util.wrk.js
@@ -1,9 +1,15 @@
 'use strict'
 
-const { WrkApi } = require('bfx-wrk-api')
-const maxmind = require('maxmind')
-const geoIp = require('geoip-lite')
 const path = require('path')
+
+// It looks like in the next release of geoip-lite
+// we can use GEODATADIR env instead of this gloabl env var,
+// but w/out it maxmind reads old data from in node_modules
+global.geodatadir = path.join(__dirname, '../data')
+const maxmind = require('maxmind')
+
+const { WrkApi } = require('bfx-wrk-api')
+const geoIp = require('geoip-lite')
 const fs = require('fs')
 
 const newDb = path.join(__dirname, '..', 'mmdb', 'GeoLite2-ASN.mmdb')


### PR DESCRIPTION
The geo-ip lite module is reading old data because we put it in a different dir.   There is an undocumented feature to specify the dir with a global variable.  It looks like this will be improved soon with an ENV  variable in the latest develpment of the module.

Also in this PR, make the license key configurable instead of changing code in git to run scripts.  

Finally, eliminate using a "free" update to development data as that was correctly updating data in node_modules, so a developer would not know the data will never update in prod/staging.