### PR TITLE
add support of isp and connection type

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "format": "standard --fix",
     "lint": "standard",
     "update-geo-data": "./update-geo-db.sh",
-    "update-asn-data": "./update-asn-db.sh"
+    "update-asn-data": "./update-asn-db.sh",
+    "update-isp-data": "./update-isp-db.sh",
+    "update-connection-type-data": "./update-connection-type-db.sh"
   },
   "dependencies": {
     "async": "^3.2.1",

--- a/test/integration.js
+++ b/test/integration.js
@@ -118,11 +118,12 @@ describe('RPC integration', () => {
     client.request(query, (err, data) => {
       try {
         if (err) throw err
-
         assert.strictEqual(data[0], '8.8.8.8')
         assert.ok(data[1].geo)
         assert.ok(data[1].dns)
         assert.ok(data[1].asn)
+        assert.ok(data[1].isp)
+        assert.ok(data[1].connectionType)
 
         done()
       } catch (err) {
@@ -145,6 +146,8 @@ describe('RPC integration', () => {
         assert.ok(data[1].geo)
         assert.ok(data[1].dns)
         assert.ok(data[1].asn)
+        assert.ok(data[1].isp)
+        assert.ok(data[1].connectionType)
 
         done()
       } catch (err) {
@@ -167,6 +170,8 @@ describe('RPC integration', () => {
         assert.ok(data[1].geo)
         assert.ok(data[1].dns)
         assert.ok(data[1].asn)
+        assert.ok(data[1].isp)
+        assert.ok(data[1].connectionType)
 
         done()
       } catch (err) {
@@ -192,6 +197,52 @@ describe('RPC integration', () => {
           'owned by google'
         )
 
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+  }).timeout(7000)
+
+  it('geo-isp: retrieves ips ISP', (done) => {
+    const query = {
+      action: 'getIpIsp',
+      args: ['53.1.34.21']
+    }
+
+    client.request(query, (err, data) => {
+      try {
+        if (err) throw err
+
+        assert.strictEqual(
+          data[0], '53.1.34.21', 'result contains queried ip'
+        )
+
+        const res = data[1]
+        assert.strictEqual(res.isp, 'Mercedes-Benz Group')
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+  }).timeout(7000)
+
+  it('getIpConnectionType: retrieves ips connection type', (done) => {
+    const query = {
+      action: 'getIpConnectionType',
+      args: ['53.1.34.21']
+    }
+
+    client.request(query, (err, data) => {
+      try {
+        if (err) throw err
+
+        assert.strictEqual(
+          data[0], '53.1.34.21', 'result contains queried ip'
+        )
+
+        const res = data[1]
+        assert.strictEqual(res.connection_type, 'Cable/DSL')
         done()
       } catch (err) {
         done(err)

--- a/update-connection-type-db.sh
+++ b/update-connection-type-db.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+trap '[[ -f "${TMPFILE}" ]] && rm --force "${TMPFILE}"' 'EXIT'
+
+readonly DESTDIR="${DESTDIR:-mmdb}"
+readonly ARCHIVE="${DESTDIR}/GeoIP2-Connection-Type.tar.gz"
+readonly LOCAL_TIMESTAMP="$(date +'%s' --reference="${ARCHIVE}" 2>/dev/null)"
+readonly MAXMIND_LICENSE="${MAXMIND_LICENSE:-$(head --quiet --lines=1 'MAXMIND_KEY' 2>/dev/null)}"
+
+[[ "${MAXMIND_LICENSE:-}" =~ ^[[:alnum:]]+$ ]] || {
+  echo "${BASH_SOURCE[0]##*/}: fatal error: license key has not been provided." >&2
+  exit 1
+}
+
+[[ -d "${DESTDIR}" ]] \
+  || mkdir --parents "${DESTDIR}"
+
+curl --silent --fail --output "${ARCHIVE}" --time-cond "${ARCHIVE}" --location "https://download.maxmind.com/app/geoip_download?edition_id=GeoIP2-Connection-Type&license_key=${MAXMIND_LICENSE}&suffix=tar.gz" || {
+  echo "${BASH_SOURCE[0]##*/}: fatal error: download failed." >&2
+  exit 1
+}
+
+[[ "${LOCAL_TIMESTAMP}" = "$(date +'%s' --reference="${ARCHIVE}" 2>/dev/null)" ]] || {
+  readonly TMPFILE="$(mktemp -p "${DESTDIR}" -t 'GeoIP2-Connection-Type.mmdb.XXXXXXXXXXXXXXXX')"
+
+  tar --extract --directory "${DESTDIR}" --strip-components=1 --wildcards '*.mmdb' \
+    --transform='flags=rSH;s|GeoIP2-Connection-Type\.mmdb$|'"${TMPFILE##*/}"'|g' --file "${ARCHIVE}" || exit 1
+
+  cat "${TMPFILE}" >"${DESTDIR}/GeoIP2-Connection-Type.mmdb"
+}

--- a/update-isp-db.sh
+++ b/update-isp-db.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+trap '[[ -f "${TMPFILE}" ]] && rm --force "${TMPFILE}"' 'EXIT'
+
+readonly DESTDIR="${DESTDIR:-mmdb}"
+readonly ARCHIVE="${DESTDIR}/GeoIP2-ISP.tar.gz"
+readonly LOCAL_TIMESTAMP="$(date +'%s' --reference="${ARCHIVE}" 2>/dev/null)"
+readonly MAXMIND_LICENSE="${MAXMIND_LICENSE:-$(head --quiet --lines=1 'MAXMIND_KEY' 2>/dev/null)}"
+
+[[ "${MAXMIND_LICENSE:-}" =~ ^[[:alnum:]]+$ ]] || {
+  echo "${BASH_SOURCE[0]##*/}: fatal error: license key has not been provided." >&2
+  exit 1
+}
+
+[[ -d "${DESTDIR}" ]] \
+  || mkdir --parents "${DESTDIR}"
+
+curl --silent --fail --output "${ARCHIVE}" --time-cond "${ARCHIVE}" --location "https://download.maxmind.com/app/geoip_download?edition_id=GeoIP2-ISP&license_key=${MAXMIND_LICENSE}&suffix=tar.gz" || {
+  echo "${BASH_SOURCE[0]##*/}: fatal error: download failed." >&2
+  exit 1
+}
+
+[[ "${LOCAL_TIMESTAMP}" = "$(date +'%s' --reference="${ARCHIVE}" 2>/dev/null)" ]] || {
+  readonly TMPFILE="$(mktemp -p "${DESTDIR}" -t 'GeoIP2-ISP.mmdb.XXXXXXXXXXXXXXXX')"
+
+  tar --extract --directory "${DESTDIR}" --strip-components=1 --wildcards '*.mmdb' \
+    --transform='flags=rSH;s|GeoIP2-ISP\.mmdb$|'"${TMPFILE##*/}"'|g' --file "${ARCHIVE}" || exit 1
+
+  cat "${TMPFILE}" >"${DESTDIR}/GeoIP2-ISP.mmdb"
+}

--- a/workers/api.net.util.wrk.js
+++ b/workers/api.net.util.wrk.js
@@ -12,7 +12,9 @@ const { WrkApi } = require('bfx-wrk-api')
 const geoIp = require('geoip-lite')
 const fs = require('fs')
 
-const newDb = path.join(__dirname, '..', 'mmdb', 'GeoLite2-ASN.mmdb')
+const asnMMDB = path.join(__dirname, '..', 'mmdb', 'GeoLite2-ASN.mmdb')
+const ispMMDB = path.join(__dirname, '..', 'mmdb', 'GeoIP2-ISP.mmdb')
+const connectionTypeMMDB = path.join(__dirname, '..', 'mmdb', 'GeoIP2-Connection-Type.mmdb')
 
 class WrkUtilNetApi extends WrkApi {
   constructor (conf, ctx) {
@@ -37,6 +39,8 @@ class WrkUtilNetApi extends WrkApi {
         ctx.lru_0 = this.lru_0
         ctx.asn_db = this.asnDb
         ctx.geoIp = this.geoIp
+        ctx.isp_db = this.ispDb
+        ctx.connectionType_db = this.connectionTypeDb
         break
     }
 
@@ -62,11 +66,27 @@ class WrkUtilNetApi extends WrkApi {
 
       this.geoIp = geoIp
 
-      this.asnDb = await maxmind.open(newDb, {
+      this.asnDb = await maxmind.open(asnMMDB, {
         watchForUpdates: true,
         watchForUpdatesNonPersistent: true,
         watchForUpdatesHook: () => {
           process.stdout.write('ASN database has been reloaded\n')
+        }
+      })
+
+      this.ispDb = await maxmind.open(ispMMDB, {
+        watchForUpdates: true,
+        watchForUpdatesNonPersistent: true,
+        watchForUpdatesHook: () => {
+          process.stdout.write('ISP database has been reloaded\n')
+        }
+      })
+
+      this.connectionTypeDb = await maxmind.open(connectionTypeMMDB, {
+        watchForUpdates: true,
+        watchForUpdatesNonPersistent: true,
+        watchForUpdatesHook: () => {
+          process.stdout.write('Connection type database has been reloaded\n')
         }
       })
 
@@ -92,8 +112,16 @@ class WrkUtilNetApi extends WrkApi {
   }
 
   testIfDbExists () {
-    if (!fs.existsSync(newDb)) {
+    if (!fs.existsSync(asnMMDB)) {
       throw new Error('GEO_DB_NOT_INSTALLED - run `npm run update-asn-data`')
+    }
+
+    if (!fs.existsSync(ispMMDB)) {
+      throw new Error('GEO_DB_NOT_INSTALLED - run `npm run update-isp-data`')
+    }
+
+    if (!fs.existsSync(connectionTypeMMDB)) {
+      throw new Error('GEO_DB_NOT_INSTALLED - run `npm run update-connection-type-data`')
     }
   }
 }

--- a/workers/api.net.util.wrk.js
+++ b/workers/api.net.util.wrk.js
@@ -37,10 +37,10 @@ class WrkUtilNetApi extends WrkApi {
     switch (type) {
       case 'api_bfx':
         ctx.lru_0 = this.lru_0
-        ctx.asn_db = this.asnDb
+        ctx.asnDb = this.asnDb
         ctx.geoIp = this.geoIp
-        ctx.isp_db = this.ispDb
-        ctx.connectionType_db = this.connectionTypeDb
+        ctx.ispDb = this.ispDb
+        ctx.connectionTypeDb = this.connectionTypeDb
         break
     }
 

--- a/workers/api.net.util.wrk.js
+++ b/workers/api.net.util.wrk.js
@@ -117,11 +117,11 @@ class WrkUtilNetApi extends WrkApi {
     }
 
     if (!fs.existsSync(ispMMDB)) {
-      throw new Error('GEO_DB_NOT_INSTALLED - run `npm run update-isp-data`')
+      throw new Error('ISP_DB_NOT_INSTALLED - run `npm run update-isp-data`')
     }
 
     if (!fs.existsSync(connectionTypeMMDB)) {
-      throw new Error('GEO_DB_NOT_INSTALLED - run `npm run update-connection-type-data`')
+      throw new Error('CONNECTION_TYPE_DB_NOT_INSTALLED - run `npm run update-connection-type-data`')
     }
   }
 }

--- a/workers/loc.api/net.util.js
+++ b/workers/loc.api/net.util.js
@@ -14,13 +14,15 @@ class UtilNet extends Api {
   getIpInfo (space, ip, cb) {
     const geoData = this.ctx.geoIp.lookup(ip)
     const asnData = this.ctx.asn_db.get(ip)
+    const ispData = this.ctx.isp_db.get(ip)
+    const connectionTypeData = this.ctx.connectionType_db.get(ip)
 
     dns.reverse(ip, (err, dnsData) => {
       if (err) return cb(err)
 
       const res = [
         ip,
-        { geo: geoData, dns: dnsData, asn: asnData }
+        { geo: geoData, dns: dnsData, asn: asnData, isp: ispData, connectionType: connectionTypeData }
       ]
 
       cb(null, res)
@@ -50,6 +52,18 @@ class UtilNet extends Api {
 
   getIpAsn (space, ip, cb) {
     const res = this.ctx.asn_db.get(ip)
+
+    cb(null, [ip, res])
+  }
+
+  getIpIsp (space, ip, cb) {
+    const res = this.ctx.isp_db.get(ip)
+
+    cb(null, [ip, res])
+  }
+
+  getIpConnectionType (space, ip, cb) {
+    const res = this.ctx.connectionType_db.get(ip)
 
     cb(null, [ip, res])
   }

--- a/workers/loc.api/net.util.js
+++ b/workers/loc.api/net.util.js
@@ -13,9 +13,9 @@ class UtilNet extends Api {
 
   getIpInfo (space, ip, cb) {
     const geoData = this.ctx.geoIp.lookup(ip)
-    const asnData = this.ctx.asn_db.get(ip)
-    const ispData = this.ctx.isp_db.get(ip)
-    const connectionTypeData = this.ctx.connectionType_db.get(ip)
+    const asnData = this.ctx.asnDb.get(ip)
+    const ispData = this.ctx.ispDb.get(ip)
+    const connectionTypeData = this.ctx.connectionTypeDb.get(ip)
 
     dns.reverse(ip, (err, dnsData) => {
       if (err) return cb(err)
@@ -51,19 +51,19 @@ class UtilNet extends Api {
   }
 
   getIpAsn (space, ip, cb) {
-    const res = this.ctx.asn_db.get(ip)
+    const res = this.ctx.asnDb.get(ip)
 
     cb(null, [ip, res])
   }
 
   getIpIsp (space, ip, cb) {
-    const res = this.ctx.isp_db.get(ip)
+    const res = this.ctx.ispDb.get(ip)
 
     cb(null, [ip, res])
   }
 
   getIpConnectionType (space, ip, cb) {
-    const res = this.ctx.connectionType_db.get(ip)
+    const res = this.ctx.connectionTypeDb.get(ip)
 
     cb(null, [ip, res])
   }


### PR DESCRIPTION
- Add support for `ISP` and `Connection Type` using `MAXMIND`
- Update `getIpInfo` to include additional `ISP` and `connectionType` info.
- Add endpoint `getIpIsp` to get IP ISP details
- Add endpoint `getIpConnectionType` to get IP connection type details

[Ticket](https://app.asana.com/1/29923630752984/project/1210874618681729/task/1210874619517880) 
