### PR TITLE
add confidence score for geoIp

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ export MAXMIND_LICENSE='your secret license'
 ```
 npm run update-geo-data
 npm run update-asn-data
+npm run update-isp-data
+npm run update-connection-type-data
 ```
 
 ### Periodic Updates for Geo/ASN data

--- a/config/net.util.json.example
+++ b/config/net.util.json.example
@@ -1,3 +1,4 @@
 {
-  "grcServices": [ "rest:util:net" ]
+  "grcServices": [ "rest:util:net" ],
+  "maxAccuracyRadius": 500
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -249,4 +249,54 @@ describe('RPC integration', () => {
       }
     })
   }).timeout(7000)
+
+  it('geo-ip: retrieves ips with accuracy_radius < 500km has confidence score > 0', (done) => {
+    const query = {
+      action: 'getIpGeo',
+      args: ['2.125.160.216']
+    }
+
+    client.request(query, (err, data) => {
+      try {
+        if (err) throw err
+
+        assert.strictEqual(
+          data[0], '2.125.160.216', 'result contains queried ip'
+        )
+
+        const res = data[1]
+        assert.ok(res.area < 500)
+        assert.ok(res.confidenceScore > 0 && res.confidenceScore < 1)
+        assert.strictEqual(res.country, 'GB')
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+  }).timeout(7000)
+
+  it('geo-ip: retrieves ips with accuracy_radius > 500km has confidence score=0', (done) => {
+    const query2 = {
+      action: 'getIpGeo',
+      args: ['8.8.8.8']
+    }
+
+    client.request(query2, (err, data) => {
+      try {
+        if (err) throw err
+
+        assert.strictEqual(
+          data[0], '8.8.8.8', 'result contains queried ip'
+        )
+
+        const res = data[1]
+        assert.ok(res.area > 500)
+        assert.strictEqual(res.confidenceScore, 0)
+        assert.strictEqual(res.country, 'US')
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+  }).timeout(7000)
 })

--- a/workers/api.net.util.wrk.js
+++ b/workers/api.net.util.wrk.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('path')
-
+const _ = require('lodash')
 // It looks like in the next release of geoip-lite
 // we can use GEODATADIR env instead of this gloabl env var,
 // but w/out it maxmind reads old data from in node_modules
@@ -41,6 +41,10 @@ class WrkUtilNetApi extends WrkApi {
         ctx.geoIp = this.geoIp
         ctx.ispDb = this.ispDb
         ctx.connectionTypeDb = this.connectionTypeDb
+        ctx.conf = ctx.conf || {}
+        _.extend(ctx.conf, {
+          maxAccuracyRadius: this.conf.util.maxAccuracyRadius
+        })
         break
     }
 

--- a/workers/loc.api/net.util.js
+++ b/workers/loc.api/net.util.js
@@ -91,21 +91,20 @@ class UtilNet extends Api {
 
   _getGeoIp (ip) {
     const res = this.ctx.geoIp.lookup(ip)
-    const confidenceScore = this._calculateConfidenceScore(res)
+    const { maxAccuracyRadius } = this.ctx.conf
+
+    const confidenceScore = this._calculateConfidenceScore(res, maxAccuracyRadius)
     return { ...res, confidenceScore }
   }
 
-  _calculateConfidenceScore (geo) {
+  _calculateConfidenceScore (geo, maxAccuracyRadius) {
     if (!geo || geo.area == null) {
       return 0
     }
     const accuracyRadius = geo.area
 
-    // Define a max expected radius beyond which confidence is zero
-    const maxExpectedRadius = 500 // kilometers
-
     // Simple linear mapping of radius to confidence score
-    const confidence = Math.max(0, Math.min(1, 1 - (accuracyRadius / maxExpectedRadius)))
+    const confidence = Math.max(0, Math.min(1, 1 - (accuracyRadius / maxAccuracyRadius)))
 
     return confidence
   }

--- a/workers/loc.api/net.util.js
+++ b/workers/loc.api/net.util.js
@@ -20,10 +20,9 @@ class UtilNet extends Api {
     dns.reverse(ip, (err, dnsData) => {
       if (err) return cb(err)
 
-      const confidenceScore = this._calculateConfidenceScore(geoData)
       const res = [
         ip,
-        { geo: geoData, dns: dnsData, asn: asnData, isp: ispData, connectionType: connectionTypeData, confidenceScore }
+        { geo: geoData, dns: dnsData, asn: asnData, isp: ispData, connectionType: connectionTypeData }
       ]
 
       cb(null, res)


### PR DESCRIPTION
- Calculates confidence score for `geoIp` based on the `accuracy_radius`.
- Higher the `accuracy_radius` lesser the confidence, shorter the `accuracy_radius` better the `confidenceScore`


[Ticket](https://app.asana.com/1/29923630752984/project/1210874618681729/task/1211183503939138)